### PR TITLE
Adopt the binary-bridge Zipline engine

### DIFF
--- a/gradle/deps.versions.toml
+++ b/gradle/deps.versions.toml
@@ -109,7 +109,7 @@ konnection = "1.4.5"
 # -CUSTOM-2 = Kotlin 2.4 rebuild (ExtensionPointDescriptor cast fix in zipline-kotlin-plugin).
 # Maven Central's 1.27.2-CUSTOM is the STALE pre-2.4 build under the same version — never
 # downgrade to it. Published to mavenLocal + GitHub Packages (Shabinder/zipline).
-zipline = "1.27.2-CUSTOM-5-qjs2026"
+zipline = "1.27.2-CUSTOM-6-binbridge"
 sqliteJdbcDriver = "3.53.2.0"
 composeHotReload = "1.2.0-beta01" # brings MCP server for agent-driven UI control (get_semantic_tree/click/type_text)
 


### PR DESCRIPTION
Points the catalog at `1.27.2-CUSTOM-6-binbridge`, which carries `ByteArray` payloads beside the JSON rather than inside it. A 256 KB round trip drops from **1,227 ms to 210 µs**.

Engine change: Shabinder/zipline#2.

Published alongside `CUSTOM-5-qjs2026`, never over it — a parallel branch still resolves that version, and overwriting it in `~/.m2` would have broken those builds silently.

All 14 extension bundles rebuild against this and load in QuickJS; saavn and spotify answer live searches across the new channel, which is the only thing that proves `bind`/`take` still agree after a channel signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)