### PR TITLE
AGP 9, CMP 1.12.0, compileSdk 37, Gradle 9.7.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 
 plugins {
-  id(deps.plugins.android.library.get().pluginId)
+  id(deps.plugins.android.kmp.library.get().pluginId)
   id(deps.plugins.kotlin.multiplatform.get().pluginId)
   id(deps.plugins.kotlin.parcelize.get().pluginId)
   id(deps.plugins.kotlin.serialization.get().pluginId)
@@ -98,49 +98,20 @@ repositories {
   }
 }
 
-android {
-  namespace = "in.shabinder.soundbound.extensions"
-  compileSdk = deps.versions.androidCompileSdk.get().toInt()
-
-  defaultConfig {
-    minSdk = deps.versions.androidMinSdk.get().toInt()
-  }
-
-  sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-
-  compileOptions {
-    isCoreLibraryDesugaringEnabled = true
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-  }
-
-  tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
-  }
-
-  buildTypes {
-    getByName("release") {
-      isMinifyEnabled = false
-    }
-  }
-
-  kotlin {
-    jvmToolchain {
-      languageVersion.set(JavaLanguageVersion.of(21))
-    }
-  }
-
-  dependencies {
-    coreLibraryDesugaring(deps.androidx.desugar)
-  }
+dependencies {
+  coreLibraryDesugaring(deps.androidx.desugar)
 }
 
 kotlin {
   iosArm64()
   iosSimulatorArm64()
-  androidTarget {
-    publishLibraryVariants("release", "debug")
+  androidLibrary {
+    namespace = "in.shabinder.soundbound.extensions"
+    compileSdk = deps.versions.androidCompileSdk.get().toInt()
+    minSdk = deps.versions.androidMinSdk.get().toInt()
+    enableCoreLibraryDesugaring = true
   }
+  jvmToolchain(21)
   jvm {
     testRuns["test"].executionTask.configure {
       useJUnit()

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id(deps.plugins.android.library.get().pluginId)
+  id(deps.plugins.android.kmp.library.get().pluginId)
   id(deps.plugins.kotlin.multiplatform.get().pluginId)
   id("maven-publish")
 }
@@ -12,9 +12,13 @@ version = "1.0.1"
 kotlin {
   iosArm64()
   iosSimulatorArm64()
-  androidTarget {
-    publishLibraryVariants("release", "debug")
+  androidLibrary {
+    namespace = "in.shabinder.soundbound.compose"
+    compileSdk = deps.versions.androidCompileSdk.get().toInt()
+    minSdk = deps.versions.androidMinSdk.get().toInt()
+    enableCoreLibraryDesugaring = true
   }
+  jvmToolchain(21)
   jvm {
     testRuns["test"].executionTask.configure {
       useJUnit()
@@ -49,39 +53,6 @@ repositories {
   }
 }
 
-android {
-  namespace = "in.shabinder.soundbound.compose"
-  compileSdk = deps.versions.androidCompileSdk.get().toInt()
-
-  defaultConfig {
-    minSdk = deps.versions.androidMinSdk.get().toInt()
-  }
-
-  //sourceSets["main"].manifest.srcFile("../src/androidMain/AndroidManifest.xml")
-
-  compileOptions {
-    isCoreLibraryDesugaringEnabled = true
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-  }
-
-  tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
-  }
-
-  buildTypes {
-    getByName("release") {
-      isMinifyEnabled = false
-    }
-  }
-
-  kotlin {
-    jvmToolchain {
-      languageVersion.set(JavaLanguageVersion.of(21))
-    }
-  }
-
-  dependencies {
-    coreLibraryDesugaring(deps.androidx.desugar)
-  }
+dependencies {
+  coreLibraryDesugaring(deps.androidx.desugar)
 }

--- a/gradle/deps.versions.toml
+++ b/gradle/deps.versions.toml
@@ -12,7 +12,7 @@ kotlin = "2.4.10"
 # So CMP does not UNBLOCK the AGP 9 chain (as the old note assumed) -- it is PART of it. Bump
 # jbCompose + androidGradle + androidCompileSdk + androidx-core + Gradle together.
 # See Docs/PLANS/2026-09-dependency-upgrade.md.
-jbCompose = "1.11.1"
+jbCompose = "1.12.0"
 # HOLD at 8.13.2 — blocked by androidx.baselineprofile, verified 2026-09-04.
 # The Kotlin/CMP part of the old chain has cleared, and AGP 9.4.0 gets further than before:
 # removing `kotlin-android` from :android, :android-ffmpeg and :baselineprofile satisfies AGP 9's
@@ -24,14 +24,14 @@ jbCompose = "1.11.1"
 # androidx.baselineprofile ships AGP 9 support; nothing else blocks the tranche.
 # Google's agp-9-upgrade skill remains off-limits for KMP projects.
 # Full findings: Docs/PLANS/2026-09-dependency-upgrade.md.
-androidGradle = "8.13.2"
+androidGradle = "9.4.0"
 coroutines = "1.11.0"
 kotlinxSerialization = "1.11.0"
 
 # Android SDK versions
-androidCompileSdk = "36"
+androidCompileSdk = "37"
 androidMinSdk = "21"
-androidTargetSdk = "36"
+androidTargetSdk = "37"
 androidBuildTools = "36.1.0"
 
 # Build tools & plugins
@@ -205,7 +205,7 @@ compose-material3-window-size = { group = "androidx.compose.material3", name = "
 androidx-activity = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 # HOLD at 1.17.0: androidx.core:core-ktx 1.18+ requires compileSdk 37 + AGP 9.x.
 # Blocked by the AGP 8.13.2 hold (see `androidGradle` above). Bump together with AGP 9.
-androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.17.0" }
+androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.18.0" }
 androidx-splash = { group = "androidx.core", name = "core-splashscreen", version = "1.2.0" }
 
 # Lifecycle
@@ -222,6 +222,10 @@ androidx-media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exop
 androidx-media3-exoplayer-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "androidxMedia3" }
 androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "androidxMedia3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }
+# media3-session dropped its transitive androidx.media dependency in 1.11.0, but
+# MusicSessionCallback/SoundBoundPlayerService import androidx.media.utils.MediaConstants directly,
+# so it is declared explicitly rather than inherited.
+androidx-mediaCompat = { group = "androidx.media", name = "media", version = "1.8.0" }
 androidx-media3-common = { group = "androidx.legacy", name = "legacy-support-v4", version = "1.0.0" }
 
 # Startup
@@ -481,7 +485,11 @@ android-app-notifier = { group = "com.github.amitbd1508", name = "AppUpdater", v
 android-phoenix = { group = "com.jakewharton", name = "process-phoenix", version = "3.0.0" }
 
 # FuzzyWuzzy
-fuzzy-wuzzy = { group = "io.github.shabinder", name = "fuzzywuzzy", version = "1.1" }
+# The platform artifact, not the KMP root module: fuzzywuzzy 1.1's Gradle metadata predates the
+# standard JVM attributes, so from Gradle 9.6 the desktop target cannot choose between its
+# debug/release/jvm variants ("cannot choose between ... jvmApiElements-published"). The library
+# is JVM-only regardless, so both android and desktop take the same jar.
+fuzzy-wuzzy = { group = "io.github.shabinder", name = "fuzzywuzzy-jvm", version = "1.1" }
 
 # KSoup
 ksoup-html = { group = "com.mohamedrejeb.ksoup", name = "ksoup-html", version = "0.6.0" }
@@ -629,6 +637,8 @@ koin-android = ["koin-compose", "koin-android"]
 # Android
 android-application = { id = "com.android.application", version.ref = "androidGradle" }
 android-library = { id = "com.android.library", version.ref = "androidGradle" }
+# AGP 9: KMP modules must use this instead of com.android.library.
+android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "androidGradle" }
 android-test = { id = "com.android.test", version.ref = "androidGradle" }
 
 # Compose

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jun 28 01:54:11 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Moves the catalog to AGP 9.4.0 / Compose Multiplatform 1.12.0 / compileSdk 37 / core-ktx 1.18.0, and both library modules onto `com.android.kotlin.multiplatform.library` — which AGP 9 requires in place of `com.android.library` for any module that also applies the KMP plugin.

That plugin replaces the `androidTarget()` declaration too, so `publishLibraryVariants("release", "debug")` goes away: it produces a single publishable Android variant rather than a debug/release pair.

The DSL is much smaller than the old `android { }` block — no `defaultConfig`, no `compileOptions`, no `buildTypes`, and no `targetSdk` (app-only in AGP 9). Desugaring becomes `enableCoreLibraryDesugaring`; the Java level comes from the Kotlin toolchain.

### Two dependency corrections the upgrade surfaced

**`androidx-mediaCompat` added.** media3-session dropped its transitive `androidx.media` dependency in 1.11.0, leaving `androidx.media:media:1.0.0` on the classpath — too old for the `MediaConstants` that `MusicSessionCallback` and `SoundBoundPlayerService` import directly. Aliased `mediaCompat` because a leaf `androidx-media` would collide with the `androidx-media3-*` accessor group.

**`fuzzywuzzy` → `fuzzywuzzy-jvm`.** Its 1.1 module metadata predates the standard JVM attributes, so from Gradle 9.6 the desktop target cannot choose between its debug/release/jvm variants. The library is JVM-only regardless.

### Verification
Consumed by the root build; `:android:assembleDebug`, `:desktop:compileKotlinDesktop` and `:android:bundlePlaystoreRelease` all pass, and the macos-arm64 release candidate builds and passes `validate.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TmFzrPY48wmc63jGbMJKWs

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR upgrades the shared build catalog to AGP 9.4.0, Compose Multiplatform 1.12.0, compile/target SDK 37, AndroidX Core 1.18.0, and Gradle 9.7.1.
- Migrates both Kotlin Multiplatform modules to AGP 9's Android KMP library plugin and DSL.
- Consolidates Android publication from explicit debug/release variants into the new plugin's single publishable variant.
- Preserves Java 21 toolchains and core-library desugaring under the new DSL.
- Corrects the published MediaCompat and FuzzyWuzzy dependency coordinates.
- No actionable correctness, security, or repository-rule violations were identified.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete correctness, security, publication, or build-workflow failure identified.

The Android target migration is consistent across both KMP modules, publication automation does not depend on the removed variant names, and the dependency catalog corrections do not create an incompatible local source-set path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| build.gradle.kts | Migrates the root module to AGP 9's Android KMP library DSL while retaining SDK, toolchain, and desugaring settings. |
| compose/build.gradle.kts | Applies the same Android KMP migration to the Compose compatibility module. |
| gradle/deps.versions.toml | Updates the coordinated build stack and corrects two consumer-facing dependency aliases. |
| gradle/wrapper/gradle-wrapper.properties | Updates the Gradle wrapper distribution from 9.5.0 to 9.7.1. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Version catalog] --> G[Gradle 9.7.1]
  C --> A[AGP 9.4.0]
  C --> CMP[Compose Multiplatform 1.12.0]
  A --> R[Root KMP library]
  A --> M[Compose compatibility module]
  R --> AR[Single Android publication]
  M --> AM[Single Android publication]
  C --> PC[Published dependency catalog]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["build: AGP 9, CMP 1.12.0, compileSdk 37,..."](https://github.com/shabinder/soundbound-extensions-lib/commit/75a436f7c5f36a63e158a8e1f36c31a31134bd8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60405807)</sub>

**Context used:**

- Knowledge Base — [Library build and publication](https://app.greptile.com/shabinder/-/custom-context/knowledge-base/shabinder/soundbound-extensions-lib/-/docs/library-build-and-publication.md)

<!-- /greptile_comment -->